### PR TITLE
strftimeの多用を避けるためフォーマットを作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,4 @@ gem "pry-rails"
 gem "dotenv-rails"
 
 gem "devise"
+gem "rails-i18n"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.0.1)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.0.2)
       actionpack (= 8.0.2)
       activesupport (= 8.0.2)
@@ -381,6 +384,7 @@ DEPENDENCIES
   pry-rails
   puma (>= 5.0)
   rails (~> 8.0.2)
+  rails-i18n
   rubocop-rails-omakase
   selenium-webdriver
   solid_cable

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,16 +2,16 @@
   <%= link_to "新規投稿", new_post_path ,class: "new_link" %>
   <%= link_to "実行済み一覧", completed_index_posts_path %>
     <% @posts.each do |due_date, posts| %>
-      <h2><%= due_date.strftime("%Y年%m月%d日") %></h2>
+      <h2><%= l due_date %></h2>
         <ul>
           <% posts.each do |post| %>
             <li class="posts-index-item">
               <div class="post-content">
                 <%= link_to(post.content, post_path(post.id)) %>
               </div>
-              締切期限 <%= post.due_date.strftime("%Y/%m/%d %H:%M") %>
+              締切期限 <%= l(post.due_date, format: :deadline )%>
                 <% unless post.is_completed %>
-                  <%= button_to "実行済み", mark_post_path(post, is_completed: "true"), method: :patch %>
+                  <%= button_to "実行済み", mark_post_path(post), method: :patch %>
                 <% end %>
             </li>
           <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,7 +9,7 @@
               <div class="post-content">
                 <%= link_to(post.content, post_path(post.id)) %>
               </div>
-              締切期限 <%= l(post.due_date, format: :deadline )%>
+              締切期限 <%= l(post.due_date )%>
                 <% unless post.is_completed %>
                   <%= button_to "実行済み", mark_post_path(post), method: :patch %>
                 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -6,6 +6,7 @@
       </p>
       <div class="post-time">
         <%= @post.created_at %>
+    
       </div>
       <div class="post-menus">
         <%= link_to "編集", edit_post_path(@post) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,7 +15,7 @@ module ToDoList
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
-
+    config.i18n.default_locale = :ja
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,5 @@
+ja:
+  time:
+    formats:
+      default: "%-m/%-d"
+      deadline: "%H:%M"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,7 @@
 ja:
+  date:
+    formats:
+      default: "%-m月%-d日"
   time:
     formats:
-      default: "%-m/%-d"
-      deadline: "%H:%M"
+      default: "%H:%M"


### PR DESCRIPTION
strftimeを多用することで後から修正を加える時に大変になる。そこで日付や期日の表示をフォーマット化した。
フォーマットは、日付を月日で、締切期限を時間のみの表示に修正した。
<img width="740" height="673" alt="スクリーンショット 2025-07-21 14 52 32" src="https://github.com/user-attachments/assets/075e7fce-ce9c-4773-92d5-f0e44e507c2d" />

